### PR TITLE
Set prod host from DOMAIN_NAME env var

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -13,7 +13,7 @@ use Mix.Config
 # which you typically run after static files are built.
 config :docset_api, DocsetApi.Endpoint,
   http: [port: System.get_env("PORT")],
-  url: [host: System.get_env("SECRET_KET_BASE"), port: 80],
+  url: [host: System.get_env("DOMAIN_NAME"), port: 80],
   cache_static_manifest: "priv/static/manifest.json"
 
 # Do not print debug messages in production


### PR DESCRIPTION
The config appears to have got mixed up and the value for `host` was set to `System.get_env("SECRET_KEY_BASE")` :grimacing: 

This is a small update to use the environment variable `DOMAIN_NAME` instead.