### PR TITLE
Update child specs for sub-processes

### DIFF
--- a/lib/builder_server.ex
+++ b/lib/builder_server.ex
@@ -9,7 +9,7 @@ defmodule DocsetApi.BuilderServer do
 
   ## External API
 
-  def start_link do
+  def start_link(_opts) do
     Logger.info("Starting BuilderServer")
     GenServer.start_link(@name, %{}, name: @name)
   end

--- a/lib/docset_api.ex
+++ b/lib/docset_api.ex
@@ -4,13 +4,11 @@ defmodule DocsetApi do
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
-    import Supervisor.Spec
-
     # Define workers and child supervisors to be supervised
     children = [
       # Start the endpoint when the application starts
-      supervisor(DocsetApi.Endpoint, []),
-      supervisor(DocsetApi.BuilderServer, []),
+      DocsetApi.Endpoint,
+      DocsetApi.BuilderServer,
       {Phoenix.PubSub, [name: DocsetApi.PubSub, adapter: Phoenix.PubSub.PG2]}
       # Start your own worker by calling: DocsetApi.Worker.start_link(arg1, arg2, arg3)
       # worker(DocsetApi.Worker, [arg1, arg2, arg3]),


### PR DESCRIPTION
The old `Supervisor.Spec` style of specifying the supervisor's child processes was throwing deprecation warnings, so I updated it to the new style, per the [Supervisor child_spec documentation](https://hexdocs.pm/elixir/Supervisor.html#module-child_spec-1).